### PR TITLE
Fixed Water Droplet, flipped the character depending on velocity, worked on wall jump

### DIFF
--- a/Game/Assets/Scenes/Main.unity
+++ b/Game/Assets/Scenes/Main.unity
@@ -2107,6 +2107,7 @@ GameObject:
   - component: {fileID: 1210756875}
   - component: {fileID: 1210756880}
   - component: {fileID: 1210756881}
+  - component: {fileID: 1210756882}
   m_Layer: 2
   m_Name: Player
   m_TagString: Untagged
@@ -2202,7 +2203,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4476975929a1f9b49a8ea728b92aabb1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  playerMovement: {fileID: 0}
+  playerMovement: {fileID: 1210756877}
 --- !u!114 &1210756880
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2236,6 +2237,21 @@ MonoBehaviour:
   - {fileID: 742661954, guid: 5911d50a18c39e44895bb06af4f87839, type: 3}
   rend: {fileID: 1563375251}
   period: 0.1
+--- !u!114 &1210756882
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1210756873}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 197ace0b56a225443a0bb374cef2f113, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  waterAmount: 100
+  dryingRate: 3
+  healthBarSlider: {fileID: 269145257}
 --- !u!4 &1238466116 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8214778688951250306, guid: 8e3519ecb04b88847b0e61ec105624b7, type: 3}

--- a/Game/Assets/Scripts/PlayerAnimation.cs
+++ b/Game/Assets/Scripts/PlayerAnimation.cs
@@ -6,6 +6,7 @@ public class PlayerAnimation : MonoBehaviour {
     [SerializeField] private List<Sprite> idleSprites;
     private int idleNum;
     [SerializeField] private SpriteRenderer rend;
+    private Rigidbody2D rigidBody;
 
     [SerializeField] private float period = 1f;
     private float lastChanged;
@@ -14,13 +15,12 @@ public class PlayerAnimation : MonoBehaviour {
     public enum animationState {
         idle
     }
-    // Start is called before the first frame update
-    void Start()
+
+    private void Start()
     {
-        
+        rigidBody = GetComponent<Rigidbody2D>();
     }
 
-    // Update is called once per frame
     void Update()
     {
         if ((Time.time - lastChanged) >= period)
@@ -36,5 +36,10 @@ public class PlayerAnimation : MonoBehaviour {
 
             lastChanged = Time.time;
         }
+
+        if (rigidBody.velocity.x > 0)//simple flip sprite based on velocity(to make it look the direction of movement)
+            rend.flipX = false;
+        else if (rigidBody.velocity.x < 0)
+            rend.flipX = true;
     }
 }

--- a/Game/Assets/Scripts/PlayerMovement.cs
+++ b/Game/Assets/Scripts/PlayerMovement.cs
@@ -12,11 +12,11 @@ public class PlayerMovement : MonoBehaviour
     [SerializeField] private float baseRunSpeed = 3;
     [SerializeField] private float sprintSpeedMultiplier = 2f;
     [Header("Jumping")]
-    //private bool inAir; // is this variable used?
     [SerializeField] private float jumpHeight = 5;
     [SerializeField] private float groundedDist = 1;
     [SerializeField] private float maxVertSpeed = 20;
     private bool canJump = true;
+    private bool isGrounded = false;
     [Header("Walljumping")]
     [Tooltip("Distance from side of player")] [SerializeField] private float wallJumpDist = 1f;
     [Tooltip("Side power of walljump")][SerializeField] private float wallJumpDistSide = 2f;
@@ -49,9 +49,10 @@ public class PlayerMovement : MonoBehaviour
     private void GroundJump()
     {
         RaycastHit2D groundedRaycast = Physics2D.Raycast(transform.position, -Vector2.up, groundedDist);//grounded raycast to detect if on the ground
+        isGrounded = groundedRaycast.collider != null;
         //Debug.Log($"Canjump: {canJump} Raycast: {groundedRaycast.collider != null}");
         if ((Input.GetButtonDown("Vertical") || Input.GetKeyDown(KeyCode.Space))
-            && groundedRaycast.collider != null && canJump == true) //if vertical input, is grounded, and doesn't have jump cooldown
+            && isGrounded && canJump == true) //if vertical input, is grounded, and doesn't have jump cooldown
         {
             StartCoroutine(JumpDelay());//Small cooldown for jump
             rigidBody.velocity += Vector2.up * jumpHeight;
@@ -75,6 +76,8 @@ public class PlayerMovement : MonoBehaviour
 
         float sidePower = Mathf.Exp(-2 * (Time.time - wallJumpTime));
         if (sidePower < 0.1)
+            sidePower = 0;
+        if (isGrounded) //TODO make this fix better for jumping up the same wall instead of back and forth between two
             sidePower = 0;
         if (wallJumpSideDistNow > 0)
             wallJumpSideDistNow = wallJumpDistSide * sidePower;


### PR DESCRIPTION


Ok so the funky behavior with the wall jumping is that when the character is climbing up one wall by jumping repeatedly against it, he sometimes has momentum from the wall jump which is being canceled by the sprint velocity, so if you let go of the run keys in midair you suddenly switch direction, idk just play with it and you'll see. I don't know how to fix, I at least made it so you stop having momentum when you're on the ground